### PR TITLE
coverage_name param and "imagepyramid" coverage_type added to create_coverage_resource

### DIFF
--- a/tethys_dataset_services/engines/geoserver_engine.py
+++ b/tethys_dataset_services/engines/geoserver_engine.py
@@ -1448,16 +1448,17 @@ class GeoServerSpatialDatasetEngine(SpatialDatasetEngine):
         self._handle_debug(response_dict, debug)
         return response_dict
 
-    def create_coverage_resource(self, store_id, coverage_file, coverage_type, overwrite=False, debug=False):
+    def create_coverage_resource(self, store_id, coverage_file, coverage_type, coverage_name=None, overwrite=False, debug=False):
         """
         Use this method to add coverage resources to GeoServer.
 
-        This method will result in the creation of three items: a coverage store, a coverage resource, and a layer. If store_id references a store that does not exist, it will be created. The coverage resource and the subsequent layer will be created with the same name as the image file that is uploaded.
+        This method will result in the creation of three items: a coverage store, a coverage resource, and a layer. If store_id references a store that does not exist, it will be created. The coverage resource and the subsequent layer will be created with the same name as the image file that is uploaded if the coverage_name parameter is unspecified.
 
         Args
           store_id (string): Identifier for the store to add the image to or to be created. Can be a name or a workspace name combination (e.g.: "name" or "workspace:name"). Note that the workspace must be an existing workspace. If no workspace is given, the default workspace will be assigned.
           coverage_file (string): Path to the coverage image or zip archive. Most files will require a .prj file with the Well Known Text definition of the projection. Zip this file up with the image and send the archive.
-          coverage_type: Type of coverage that is being created. Valid values include: 'geotiff', 'worldimage', 'imagemosaic', 'gtopo30', 'arcgrid', 'grassgrid', 'erdasimg', 'aig', 'gif', 'png', 'jpeg', 'tiff', 'dted', 'rpftoc', 'rst', 'nitf', 'envihdr', 'mrsid', 'ehdr', 'ecw', 'netcdf', 'erdasimg', 'jp2mrsid'.
+          coverage_type (string): Type of coverage that is being created. Valid values include: 'geotiff', 'worldimage', 'imagemosaic', 'imagepyramid', 'gtopo30', 'arcgrid', 'grassgrid', 'erdasimg', 'aig', 'gif', 'png', 'jpeg', 'tiff', 'dted', 'rpftoc', 'rst', 'nitf', 'envihdr', 'mrsid', 'ehdr', 'ecw', 'netcdf', 'erdasimg', 'jp2mrsid'.
+	  coverage_name (string): Name of the coverage resource and subsequent layer that are created. If unspecified, these will match the name of the image file that is uploaded.
           overwrite (bool, optional): Overwrite the file if it already exists.
           charset (string, optional): Specify the character encoding of the file being uploaded (e.g.: ISO-8559-1)
           debug (bool, optional): Pretty print the response dictionary to the console for debugging. Defaults to False.
@@ -1478,6 +1479,7 @@ class GeoServerSpatialDatasetEngine(SpatialDatasetEngine):
         VALID_COVERAGE_TYPES = ('geotiff',
                                 'worldimage',
                                 'imagemosaic',
+				'imagepyramid',
                                 'gtopo30',
                                 'arcgrid',
                                 'grassgrid',
@@ -1637,6 +1639,9 @@ class GeoServerSpatialDatasetEngine(SpatialDatasetEngine):
 
         # Set params
         params = {}
+
+	if coverage_name:
+	    params['coverageName'] = coverage_name
 
         if overwrite:
             params['update'] = 'overwrite'

--- a/tethys_dataset_services/engines/geoserver_engine.py
+++ b/tethys_dataset_services/engines/geoserver_engine.py
@@ -1452,7 +1452,7 @@ class GeoServerSpatialDatasetEngine(SpatialDatasetEngine):
         """
         Use this method to add coverage resources to GeoServer.
 
-        This method will result in the creation of three items: a coverage store, a coverage resource, and a layer. If store_id references a store that does not exist, it will be created. The coverage resource and the subsequent layer will be created with the same name as the image file that is uploaded if the coverage_name parameter is unspecified.
+        This method will result in the creation of three items: a coverage store, a coverage resource, and a layer. If store_id references a store that does not exist, it will be created. Unless coverage_name is specified, the coverage resource and the subsequent layer will be created with the same name as the image file that is uploaded.
 
         Args
           store_id (string): Identifier for the store to add the image to or to be created. Can be a name or a workspace name combination (e.g.: "name" or "workspace:name"). Note that the workspace must be an existing workspace. If no workspace is given, the default workspace will be assigned.


### PR DESCRIPTION
The coverage_name param allows a user to specify what the newly-created coverage resource and layer  will be called. If unspecified, the coverage resource and the subsequent layer will be created with the same name as the image file that is uploaded.

The "imagepyramid" option was added to the VALID_COVERAGE_TYPES list. This allows a user to create an imagepyramid coverage store. **This change depends on the imagepyramid extension that matches the GeoServer version.** I will be submitting a pull request to have this extension added to the Tethys docker-ized GeoServer.