### PR TITLE
Use private endpoint by default for GeoServer Reloads

### DIFF
--- a/tests/unit_tests/test_geoserver_engine.py
+++ b/tests/unit_tests/test_geoserver_engine.py
@@ -2341,7 +2341,7 @@ class TestGeoServerDatasetEngine(unittest.TestCase):
     def test_reload_ports_none(self, mock_post):
         mock_post.return_value = MockResponse(200)
         self.engine.reload()
-        rest_endpoint = self.public_endpoint + 'reload'
+        rest_endpoint = self.endpoint + 'reload'
         mock_post.assert_called_with(rest_endpoint, auth=self.auth)
 
     @mock.patch('tethys_dataset_services.engines.geoserver_engine.requests.post')
@@ -2362,14 +2362,14 @@ class TestGeoServerDatasetEngine(unittest.TestCase):
     @mock.patch('tethys_dataset_services.engines.geoserver_engine.requests.post')
     def test_reload_connection_error(self, mock_post, mock_logger):
         mock_post.side_effect = requests.ConnectionError()
-        response = self.engine.reload()
+        self.engine.reload()
         mock_logger.warning.assert_called()
 
     @mock.patch('tethys_dataset_services.engines.geoserver_engine.requests.post')
     def test_gwc_reload_ports_none(self, mock_post):
         mock_post.return_value = MockResponse(200)
         self.engine.gwc_reload()
-        rest_endpoint = self.public_endpoint.replace('rest', 'gwc/rest') + 'reload'
+        rest_endpoint = self.endpoint.replace('rest', 'gwc/rest') + 'reload'
         mock_post.assert_called_with(rest_endpoint, auth=self.auth)
 
     @mock.patch('tethys_dataset_services.engines.geoserver_engine.requests.post')
@@ -2390,7 +2390,7 @@ class TestGeoServerDatasetEngine(unittest.TestCase):
     @mock.patch('tethys_dataset_services.engines.geoserver_engine.requests.post')
     def test_gwc_reload_connection_error(self, mock_post, mock_logger):
         mock_post.side_effect = requests.ConnectionError()
-        response = self.engine.gwc_reload()
+        self.engine.gwc_reload()
         mock_logger.warning.assert_called()
 
     def test_ini_no_slash_endpoint(self):

--- a/tethys_dataset_services/engines/geoserver_engine.py
+++ b/tethys_dataset_services/engines/geoserver_engine.py
@@ -668,7 +668,7 @@ class GeoServerSpatialDatasetEngine(SpatialDatasetEngine):
     def close(self):
         self.catalog.client.close()
 
-    def reload(self, ports=None, public=True):
+    def reload(self, ports=None, public=False):
         """
         Reload the configuration from disk.
 
@@ -697,7 +697,7 @@ class GeoServerSpatialDatasetEngine(SpatialDatasetEngine):
         response_dict.pop('error', None) if not response_dict['error'] else response_dict.pop('result', None)
         return response_dict
 
-    def gwc_reload(self, ports=None, public=True):
+    def gwc_reload(self, ports=None, public=False):
         """
         Reload the GeoWebCache configuration from disk.
 


### PR DESCRIPTION
The reload and reload_gwc methods on the GeoServer engine use the public endpoint by default, which is problematic b/c the public endpoint is not always available from the calling location. Some examples include:

- when working in a containerized environment and the node ports are not exposed on a public network.
- when the public host is "localhost" and in a containerized environment (this occurs in development most often)

This PR changes the default behavior to use the (private) endpoint of the engine by default.