### PR TITLE
Revert "Dependency Fix": Remove urllib3 Pin

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,6 @@ dependencies = [
     "requests_toolbelt",
     "sqlalchemy<2",
     "psycopg2-binary",
-    "urllib3>=1.26,<2.0"
 ]
 dynamic = ["version"]
 


### PR DESCRIPTION
Reverts tethysplatform/tethys_dataset_services#29

There is a new version of geoserver-restconfig that should be compatible with the newer versions of urllib3.